### PR TITLE
update on-page descriptional texts

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -169,7 +169,8 @@ class PageHeader extends React.Component<PageHeaderProps, PageHeaderState> {
         <img src='./lean_logo.svg' style={{height: '100%', float: 'left', paddingLeft: '1em', paddingRight: '3em'}}/>
         <div style={{padding: '1em'}}>
           <div style={{fontSize: '80%'}}>
-            Live in-browser version of the <a href='https://leanprover.github.io/'>Lean theorem prover</a>.
+            Live in-browser version of the <a href='https://leanprover.github.io/'>Lean theorem prover</a>.<br/>
+            Blank right side pane means the proof checks out ok.
           </div>
           {isRunning}
         </div>
@@ -258,7 +259,7 @@ class LeanEditor extends React.Component<LeanEditorProps, LeanEditorState> {
 }
 
 const defaultValue =
-  '-- Live javascript version of Lean\n\nexample (m n : ℕ) : m + n = n + m :=\nby simp';
+  '-- An example proof in Lean\n\nexample (m n : ℕ) : m + n = n + m :=\nby simp';
 
 function App() {
   let value = defaultValue;


### PR DESCRIPTION
Problem: I tried this on mobile, and with no buttons or status text lines I just closed the site.

As a casually interested first-time visitor
In order to get hooked on Lean
I want the live site to show explanations so most visitors can understand the content and functionality of the Live site

AC01: Add explanation of right-side pane
AC02: Clarify that the thing `example ...` is a proof written in Lean.